### PR TITLE
ci: add oct-ep-target dependency

### DIFF
--- a/.github/workflows/build-cn10k.yml
+++ b/.github/workflows/build-cn10k.yml
@@ -118,7 +118,7 @@ jobs:
             sudo apt-get install -y  ucf uuid-dev wireshark-common xauth xdg-user-dirs xz-utils zlib1g-dev libgmpxx4ldbl
             sudo apt-get install -y  liblz4-dev liblzma-dev wget libzstd-dev nettle-dev lsb-release doxygen libarchive-dev
             sudo apt-get install -y  libnl-xfrm-3-dev sphinx-common python3-sphinx-rtd-theme libfdt-dev libjansson-dev libbsd-dev
-            sudo apt-get install -y  python3-pyelftools gcc-14 bzip2-doc libacl1-dev libattr1-dev libbz2-dev libgmp-dev libbpf-dev
+            sudo apt-get install -y  python3-pyelftools gcc-14 bzip2-doc libacl1-dev libattr1-dev libbz2-dev libgmp-dev libbpf-dev libconfig-dev
             source ${BASE_DIR}/artifacts/env
             DISTRO=ubuntu-`lsb_release -rs`
             echo "DISTRO=${DISTRO}" >> ${BASE_DIR}/artifacts/env
@@ -126,6 +126,8 @@ jobs:
             ccache -p
             git config --global --add safe.directory "${PWD}"
             sudo APT_ARGS='-y -q' make install-deps
+            wget "https://github.com/MarvellEmbeddedProcessors/pcie_ep_octeon_target/releases/download/oct-ep-target-cn10k-${MRVL_PKG_VERSION}-${DISTRO}-${MRVL_PKG_VERSION}/oct-ep-target-cn10k_${MRVL_PKG_VERSION}_arm64.deb"
+            sudo apt-get install -y ./"oct-ep-target-cn10k_${MRVL_PKG_VERSION}_arm64.deb"
             make build-release VPP_PLATFORM=octeon10
             mkdir -p "${PWD}/install/DEBIAN"
             mkdir -p "${PWD}/install/usr/share/vpp/api"
@@ -135,7 +137,7 @@ jobs:
             echo 'Package: vpp-'$PKG_VERSION_NAME'-cn10k'$PKG_POSTFIX >> DEBIAN/control
             echo 'Version: '$MRVL_PKG_VERSION >> DEBIAN/control
             echo "Maintainer: Jerin Jacob (jerinj@marvell.com)" >> DEBIAN/control
-            echo 'Depends: python3, python3-ply, dpdk-'$DPDK_BASE_PKG_VERSION'-cn10k (= '$DPDK_PKG_VERSION'), cpt-firmware-cn10k'${FW_PKG_POSTFIX}' (= '$CPT_PKG_VERSION')' >> DEBIAN/control
+            echo 'Depends: python3, python3-ply, dpdk-'$DPDK_BASE_PKG_VERSION'-cn10k (= '$DPDK_PKG_VERSION'), cpt-firmware-cn10k'${FW_PKG_POSTFIX}' (= '$CPT_PKG_VERSION'), oct-ep-target-cn10k (= '$MRVL_PKG_VERSION')' >> DEBIAN/control
             echo "Architecture: arm64" >> DEBIAN/control
             echo "Homepage: https://wiki.fd.io/view/VPP" >> DEBIAN/control
             echo "Description: Vector Packet Processing (VPP) for Octeon10" >> DEBIAN/control


### PR DESCRIPTION
Add oct-ep-target as a dependency for VPP build and VPP package install.