### PR TITLE
ci: upgrade action-gh-release to v2.2.2

### DIFF
--- a/.github/workflows/build-cn10k.yml
+++ b/.github/workflows/build-cn10k.yml
@@ -181,7 +181,7 @@ jobs:
           fi
         continue-on-error: true
       - name: Release VPP cn10k package
-        uses: softprops/action-gh-release@v2.0.4
+        uses: softprops/action-gh-release@v2.2.2
         if: ${{ github.event_name == 'push' }}
         with:
           draft: false


### PR DESCRIPTION
Upgrade action-gh-release to v2.2.2 to publish releases.