### PR TITLE
ci: allow manual triggers to github actions

### DIFF
--- a/.github/workflows/build-cn10k.yml
+++ b/.github/workflows/build-cn10k.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     - cron: "0 0 * * *"
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Added workflow_dispatch to enable manual
triggering via GitHub UI.