### PR TITLE
ci: move package dispatch to dao repo

### DIFF
--- a/.github/workflows/build-cn10k.yml
+++ b/.github/workflows/build-cn10k.yml
@@ -181,18 +181,3 @@ jobs:
           tag_name: vpp-${{ steps.artifacts.outputs.PKG_VERSION_NAME }}-cn10k-${{ steps.artifacts.outputs.MRVL_PKG_VERSION }}-${{ steps.artifacts.outputs.DISTRO }}-${{ steps.artifacts.outputs.TAG }}
           files: |
             ${{ github.workspace }}/artifacts/vpp-${{ steps.artifacts.outputs.PKG_VERSION_NAME }}-cn10k${{ steps.artifacts.outputs.PKG_POSTFIX }}_${{ steps.artifacts.outputs.MRVL_PKG_VERSION }}_arm64.deb
-      - name: Dispatch package update event
-        if: ${{ github.event_name == 'push' }}
-        run: |
-          curl -L \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.PPA_REPO_SECRET }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/marvellembeddedprocessors/packages/dispatches \
-            -d '{"event_type":"dispatch-event", "client_payload": {"package" : "vpp",
-            "tag": "vpp-${{ steps.artifacts.outputs.PKG_VERSION_NAME }}-cn10k-${{ steps.artifacts.outputs.MRVL_PKG_VERSION }}-${{ steps.artifacts.outputs.DISTRO }}-${{ steps.artifacts.outputs.TAG }}",
-            "dpdk_tag" : "dpdk-cn10k-${{ steps.version.outputs.DPDK_BASE_PKG_VERSION }}_${{ steps.version.outputs.DPDK_PKG_VERSION }}-${{ steps.artifacts.outputs.DISTRO }}-${{ steps.version.outputs.DPDK_PKG_VERSION }}",
-            "has_dpdk" : "true", "distro" : "${{ steps.artifacts.outputs.DISTRO }}",
-            "platform" : "cn10k",
-            "devel": "${{ steps.artifacts.outputs.IS_DEVEL }}"}}'


### PR DESCRIPTION
Move Package dispatch to DAO repo.
Run only CI for pushes to VPP repo.