### PR TITLE
ci: fix cron schedule for devel runners

### DIFF
--- a/.github/workflows/build-cn10k.yml
+++ b/.github/workflows/build-cn10k.yml
@@ -39,8 +39,14 @@ jobs:
         run: |
           mkdir -p "${PWD}/artifacts"
           git tag --points-at HEAD > /tmp/tags
-          [ -s /tmp/tags ] && PKG_POSTFIX= || PKG_POSTFIX=-devel
-          [ -s /tmp/tags ] && NIGHTLY=false || NIGHTLY=true
+          # Treat HEAD as "release" only if a release tag (YY.MM.0) points at it.
+          if git tag --points-at HEAD --list '[0-9][0-9].[0-9][0-9].0' | grep -q .; then
+            PKG_POSTFIX=
+            NIGHTLY=false
+          else
+            PKG_POSTFIX=-devel
+            NIGHTLY=true
+          fi
           echo "PKG_VERSION_NAME=`./src/scripts/version | awk -F '-' '{print $1}'`" >> "${PWD}/artifacts/env"
           echo "MRVL_PKG_VERSION=`cat MRVL_VERSION`" >> "${PWD}/artifacts/env"
           echo "CPT_PKG_VERSION=`cat DEP_PKG_VERSION | grep CPT_PKG_VERSION | awk -F'=' '{print $2}'`" >> "${PWD}/artifacts/env"


### PR DESCRIPTION
- VPP scheduled cron job only picks stable version name.
- Treat HEAD as "release" only if a release tag (YY.MM.0) points at it.